### PR TITLE
Unescape discord messages before sending to discord

### DIFF
--- a/IRC-Relay/Helpers.cs
+++ b/IRC-Relay/Helpers.cs
@@ -13,7 +13,6 @@ namespace IRCRelay
     {
         public static string UploadMarkDown(string input)
         {
-
             using (var client = new WebClient())
             {
                 client.Headers[HttpRequestHeader.ContentType] = "text/plain";
@@ -52,6 +51,11 @@ namespace IRCRelay
             return returnString;
         }
 
+            public static string Unescape(string input)
+            {
+                return Regex.Replace(input, @"\\([^A-Za-z0-9])", "$1");
+            }
+
         public static string ChannelMentionToName(string input, SocketUserMessage message)
         {
             string returnString = input;
@@ -78,7 +82,7 @@ namespace IRCRelay
 
             Regex regex = new Regex("<:[A-Za-z0-9-_]+:[0-9]+>");
             Match match = regex.Match(input);
-            if (match.Success) // contains a mention
+            if (match.Success) // contains a emoji
             {
                 string substring = input.Substring(match.Index, match.Length);
                 string[] sections = substring.Split(':');

--- a/IRC-Relay/Program.cs
+++ b/IRC-Relay/Program.cs
@@ -87,6 +87,7 @@ namespace IRCRelay
             string formatted = Helpers.MentionToUsername(messageParam.Content, message);
             formatted = Helpers.EmojiToName(formatted, message);
             formatted = Helpers.ChannelMentionToName(formatted, message);
+            formatted = Helpers.Unescape(formatted);
 
             string text = "```";
             if (formatted.Contains(text))


### PR DESCRIPTION
When you escape special discord characters (which seems to be any non-alphanumeric character) the escape character '\\' still shows up on IRC which is a bit ugly. Added a simple regex to remove that escape character before sending to IRC.