### PR TITLE
Add IRC usn and Discord id blacklists

### DIFF
--- a/IRC-Relay/IRC.cs
+++ b/IRC-Relay/IRC.cs
@@ -25,10 +25,10 @@ namespace IRCRelay
         private string targetChannel;
 
         private bool logMessages;
-        private List<string> blacklistNames;
+        private Object[] blacklistNames;
 
         public IRC(string server, int port, string nick, string channel, string loginName, 
-                   string authstring, string authuser, string targetGuild, string targetChannel, bool logMessages, List<string> blacklistNames)
+                   string authstring, string authuser, string targetGuild, string targetChannel, bool logMessages, Object[] blacklistNames)
         {
             ircClient = new IrcClient();
 

--- a/IRC-Relay/IRC.cs
+++ b/IRC-Relay/IRC.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Timers;
 using IRCRelay.Logs;
 using System.Text.RegularExpressions;
+using System.Collections.Generic;
 
 namespace IRCRelay
 {
@@ -24,9 +25,10 @@ namespace IRCRelay
         private string targetChannel;
 
         private bool logMessages;
+        private List<string> blacklistNames;
 
         public IRC(string server, int port, string nick, string channel, string loginName, 
-                   string authstring, string authuser, string targetGuild, string targetChannel, bool logMessages)
+                   string authstring, string authuser, string targetGuild, string targetChannel, bool logMessages, List<string> blacklistNames)
         {
             ircClient = new IrcClient();
 
@@ -63,6 +65,7 @@ namespace IRCRelay
             this.targetGuild = targetGuild;
             this.targetChannel = targetChannel;
             this.logMessages = logMessages;
+            this.blacklistNames = blacklistNames;
         }
 
         public void SendMessage(string username, string message)
@@ -128,6 +131,21 @@ namespace IRCRelay
         {
             if (e.Data.Nick.Equals(this.nick))
                 return;
+
+            if (blacklistNames != null) // bcompat support
+            {
+                /**
+                 * We'll loop all blacklisted names, if the sender
+                 * has a blacklisted name, we won't relay and ret out
+                 */
+                foreach (string name in blacklistNames)
+                {
+                    if (e.Data.Nick.Equals(name))
+                    {
+                        return;
+                    }
+                }
+            }
 
             if (logMessages)
                 LogManager.WriteLog(MsgSendType.IRCToDiscord, e.Data.Nick, e.Data.Message, "log.txt");

--- a/IRC-Relay/Program.cs
+++ b/IRC-Relay/Program.cs
@@ -64,7 +64,8 @@ namespace IRCRelay
                           config.IRCAuthUser,
                           config.DiscordGuildName,
                           config.DiscordChannelName,
-                          config.IRCLogMessages);
+                          config.IRCLogMessages,
+                          config.IRCNameBlacklist);
 
             irc.SpawnBot();
 
@@ -80,6 +81,21 @@ namespace IRCRelay
             if (message.Author.Id == client.CurrentUser.Id) return; // block self
 
             if (!messageParam.Channel.Name.Contains(config.DiscordChannelName)) return; // only relay trough specified channels
+
+            if (config.DiscordUserIDBlacklist != null) //bcompat support
+            {
+                /**
+                 * We'll loop blacklisted user ids. If the user ID is found,
+                 * then we return out and prevent the call
+                 */
+                foreach (string id in config.DiscordUserIDBlacklist)
+                {
+                    if (message.Author.Id == ulong.Parse(id))
+                    {
+                        return;
+                    }
+                }
+            }
 
             /* Santize discord-specific notation to human readable things */
             string formatted = Helpers.MentionToUsername(messageParam.Content, message);

--- a/IRC-Relay/settings.json
+++ b/IRC-Relay/settings.json
@@ -11,5 +11,9 @@
   "DiscordGuildName": "server name",
   "DiscordChannelName": "text channel",
   "SpamFilter": [
+  ],
+  "IRCNameBlacklist": [
+  ],
+  "DiscordUserIDBlacklist": [
   ]
 }


### PR DESCRIPTION
Fixes #12 

Adds discord userid and irc nick blacklists for the relay, that way the owner can prevent a user's messages from either side go through. Untested, as I am unable to do so.

```
  "IRCNameBlacklist": [
    "Headline"
  ],
  "DiscordUserIDBlacklist": [
    "194315619217178624"
  ]
```