### PR TITLE
Prevent IRC nipping on Discord Failures

### DIFF
--- a/IRC-Relay/Discord.cs
+++ b/IRC-Relay/Discord.cs
@@ -84,7 +84,7 @@ namespace IRCRelay
         {
             /* Create a new thread to kill the session. We cannot block
              * this Disconnect call */
-            new System.Threading.Thread(() => { session.Kill(Session.TargetBot.Discord); }).Start();
+            new System.Threading.Thread(async() => { await session.Kill(Session.TargetBot.Discord); }).Start();
 
             await Log(new LogMessage(LogSeverity.Critical, "OnDiscordDisconnect", ex.Message));
         }

--- a/IRC-Relay/Discord.cs
+++ b/IRC-Relay/Discord.cs
@@ -208,7 +208,10 @@ namespace IRCRelay
 
         public static Task Log(LogMessage msg)
         {
-            return Task.Run(() => Console.WriteLine(msg.ToString()));
+            return Task.Run(() => {
+                Console.ForegroundColor = ConsoleColor.White;
+                Console.WriteLine(msg.ToString());
+            });
         }
 
         public void Dispose()

--- a/IRC-Relay/Discord.cs
+++ b/IRC-Relay/Discord.cs
@@ -240,7 +240,7 @@ namespace IRCRelay
                 if (config.IRCLogMessages)
                     LogManager.WriteLog(MsgSendType.DiscordToIRC, msg.Author.Username, result, "log.txt");
 
-                session.SendMessage(Session.MessageDestination.IRC, result, msg.Author.Username);
+                session.SendMessage(Session.TargetBot.IRC, result, msg.Author.Username);
             }
         }
         public static string MentionToNickname(string input, SocketUserMessage message)

--- a/IRC-Relay/Discord.cs
+++ b/IRC-Relay/Discord.cs
@@ -84,7 +84,7 @@ namespace IRCRelay
         {
             /* Create a new thread to kill the session. We cannot block
              * this Disconnect call */
-            new System.Threading.Thread(() => { session.Kill(); }).Start();
+            new System.Threading.Thread(() => { session.Kill(Session.TargetBot.Discord); }).Start();
 
             await Log(new LogMessage(LogSeverity.Critical, "OnDiscordDisconnect", ex.Message));
         }
@@ -177,14 +177,14 @@ namespace IRCRelay
 
             foreach (var attachment in message.Attachments)
             {
-                session.SendMessage(Session.MessageDestination.IRC, attachment.Url, username);
+                session.SendMessage(Session.TargetBot.IRC, attachment.Url, username);
             }
 
             foreach (String part in parts) // we're going to send each line indpependently instead of letting irc clients handle it.
             {
                 if (part.Replace(" ", "").Replace("\n", "").Replace("\t", "").Length != 0) // if the string is not empty or just spaces
                 {
-                    session.SendMessage(Session.MessageDestination.IRC, part, username);
+                    session.SendMessage(Session.TargetBot.IRC, part, username);
                 }
             }
 
@@ -193,7 +193,7 @@ namespace IRCRelay
                 if (config.IRCLogMessages)
                     LogManager.WriteLog(MsgSendType.DiscordToIRC, username, url, "log.txt");
 
-                session.SendMessage(Session.MessageDestination.IRC, url, username);
+                session.SendMessage(Session.TargetBot.IRC, url, username);
             }
         }
 

--- a/IRC-Relay/Discord.cs
+++ b/IRC-Relay/Discord.cs
@@ -89,6 +89,15 @@ namespace IRCRelay
             await Log(new LogMessage(LogSeverity.Critical, "OnDiscordDisconnect", ex.Message));
         }
 
+        public void Kill()
+        {
+            try
+            {
+                this.Dispose();
+            }
+            catch { }
+        }
+
         public async Task OnDiscordMessage(SocketMessage messageParam)
         {
             string url = "";

--- a/IRC-Relay/IRC-Relay.csproj
+++ b/IRC-Relay/IRC-Relay.csproj
@@ -65,6 +65,7 @@
     <Reference Include="Meebey.SmartIrc4net, Version=0.4.5.0, Culture=neutral, PublicKeyToken=7868485fbf407e0f, processorArchitecture=MSIL">
       <HintPath>..\packages\SmartIrc4net.1.1\lib\Meebey.SmartIrc4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.1.1\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
     </Reference>
@@ -90,7 +91,6 @@
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />

--- a/IRC-Relay/IRC.cs
+++ b/IRC-Relay/IRC.cs
@@ -94,7 +94,7 @@ namespace IRCRelay
         {
             /* Create a new thread to kill the session. We cannot block
              * this Disconnect call */
-            new System.Threading.Thread(() => { session.Kill(); }).Start();
+            new System.Threading.Thread(() => { session.Kill(Session.TargetBot.Both); }).Start();
 
             Discord.Log(new LogMessage(LogSeverity.Critical, "IRCOnError", e.ErrorMessage));
         }
@@ -152,7 +152,7 @@ namespace IRCRelay
                 }
             }
 
-            session.SendMessage(Session.MessageDestination.Discord, "**<" + prefix + Regex.Escape(e.Data.Nick) + ">** " + msg);
+            session.SendMessage(Session.TargetBot.Discord, "**<" + prefix + Regex.Escape(e.Data.Nick) + ">** " + msg);
         }
     }
 }

--- a/IRC-Relay/IRC.cs
+++ b/IRC-Relay/IRC.cs
@@ -94,7 +94,7 @@ namespace IRCRelay
         {
             /* Create a new thread to kill the session. We cannot block
              * this Disconnect call */
-            new System.Threading.Thread(() => { session.Kill(Session.TargetBot.Both); }).Start();
+            new Thread(async() => await session.Kill(Session.TargetBot.Both)).Start();
 
             Discord.Log(new LogMessage(LogSeverity.Critical, "IRCOnError", e.ErrorMessage));
         }

--- a/IRC-Relay/Program.cs
+++ b/IRC-Relay/Program.cs
@@ -28,9 +28,17 @@ namespace IRCRelay
     {
         public static void Main(string[] args)
         {
+            dynamic config = null;
             Console.Title = "Discord IRC Relay (c) Michael Flaherty 2018";
-            var config = Config.ApplyJson(new StreamReader("settings.json").ReadToEnd(), new ConfigObject());
-
+            try
+            {
+                config = Config.ApplyJson(new StreamReader("settings.json").ReadToEnd(), new ConfigObject());
+            }
+            catch (FileNotFoundException ex)
+            {
+                Console.WriteLine("Startup failure: {0}", ex.Message);
+                Environment.Exit(0);
+            }
             StartSessions(config).GetAwaiter().GetResult();
         }
 

--- a/IRC-Relay/Session.cs
+++ b/IRC-Relay/Session.cs
@@ -48,19 +48,17 @@ namespace IRCRelay
             switch (bot)
             {
                 case TargetBot.Discord:
-                    discord.Dispose();
-                    new System.Threading.Thread(async() => {
-                        this.discord = new Discord(config, this);
-                        await discord.SpawnBot();
-                    }).Start();
+                    discord.Kill();
                     await Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "Discord connection closed."));
+                    await discord.SpawnBot();
                     break;
                 case TargetBot.IRC:
                     irc.Client.RfcQuit();
+                    await irc.SpawnBot();
                     await Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "IRC connection closed."));
                     break;
-                case TargetBot.Both:
-                    discord.Dispose();
+                case TargetBot.Both: // if we kill both, let main loop recover
+                    discord.Kill();
                     irc.Client.RfcQuit();
                     this.alive = false;
                     await Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "Discord connection closed."));

--- a/IRC-Relay/Session.cs
+++ b/IRC-Relay/Session.cs
@@ -43,23 +43,27 @@ namespace IRCRelay
             alive = true;
         }
 
-        public void Kill(TargetBot bot)
+        public async Task Kill(TargetBot bot)
         {
             switch (bot)
             {
                 case TargetBot.Discord:
                     discord.Dispose();
-                    Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "Discord connection closed."));
+                    new System.Threading.Thread(async() => {
+                        this.discord = new Discord(config, this);
+                        await discord.SpawnBot();
+                    }).Start();
+                    await Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "Discord connection closed."));
                     break;
                 case TargetBot.IRC:
                     irc.Client.RfcQuit();
-                    Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "IRC connection closed."));
+                    await Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "IRC connection closed."));
                     break;
                 case TargetBot.Both:
                     discord.Dispose();
                     irc.Client.RfcQuit();
                     this.alive = false;
-                    Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "Discord connection closed."));
+                    await Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "Discord connection closed."));
                     break;
             }
 

--- a/IRC-Relay/Session.cs
+++ b/IRC-Relay/Session.cs
@@ -15,6 +15,7 @@
  * this program. If not, see http://www.gnu.org/licenses/.
  */
 
+using System.Threading;
 using System.Threading.Tasks;
 using Discord;
 
@@ -50,7 +51,12 @@ namespace IRCRelay
                 case TargetBot.Discord:
                     discord.Kill();
                     await Discord.Log(new LogMessage(LogSeverity.Critical, "KillSesh", "Discord connection closed."));
-                    await discord.SpawnBot();
+                    new Thread(async() =>
+                    {
+                        Thread.Sleep(System.TimeSpan.FromSeconds(1).Milliseconds);
+                        this.discord = new Discord(config, this);
+                        await discord.SpawnBot();
+                    }).Start();
                     break;
                 case TargetBot.IRC:
                     irc.Client.RfcQuit();


### PR DESCRIPTION
This should solve the problem of the IRC relay leaving & rejoining IRC due to discord going down intermittently. 

```
2:24 PM ⇐ +r quit (~Administr@discord-relay.user.gamesurge)
2:24 PM → r joined (~Administr@gamesurge-xxxx)
2:24 PM ⇐ r quit (~Administr@gamesurge-xxxx) Registered
2:24 PM → r joined (~Administr@discord-relay.user.gamesurge)
2:24 PM +r was voiced (+v) by @ChanServ
```

Pull request will be merged once live tests prove this effective.